### PR TITLE
Add missing secure compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2025-03-20
+A patch update to fix a missing secure compare in `verify?/3`.
+
 ## [0.2.1] - 2023-10-16
 A patch update to fix dependency issues. 
 

--- a/lib/prefixed_api_key.ex
+++ b/lib/prefixed_api_key.ex
@@ -152,7 +152,7 @@ defmodule PrefixedApiKey do
   def verify?(api_key, hash, short) do
     with {:ok, key} <- parse(api_key)
       do
-      key.short_token == short && key.hash == hash
+      key.short_token == short && secure_compare(key.hash, hash)
     else
       _ -> false
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PrefixedApiKey.MixProject do
   def project do
     [
       app: :prefixed_api_key,
-      version: "0.2.1",
+      version: "0.2.2",
       elixir: "~> 1.11",
       description: "Elixir module for generating a simple Prefixed API Key",
       package: package(),


### PR DESCRIPTION
Hey,

first of all, thank you for this library!

`verify?/2` uses `secure_compare/2` added in 4b15232ac6478dc1fdf097ec93a4f0f05d870c03 to compare hashes in order to avoid timing attacks. `verify?/3` compares hashes, too, but it does not use `secure_compare/2`.  I assume that this is not intentional, so this pull request adds secure compare in this function.

If this behavior is intentional, feel free to just close this pull request :)